### PR TITLE
Fix: Correct GitHub Pages redirect logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     const redirect = sessionStorage.getItem('redirect');
     if (redirect) {
       sessionStorage.removeItem('redirect');
-      window.history.replaceState(null, null, '/sapphire-resto-website' + redirect);
+      window.history.replaceState(null, null, redirect);
     }
   </script>
 </body>

--- a/public/404.html
+++ b/public/404.html
@@ -1,8 +1,13 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta http-equiv="refresh" content="0; URL='./index.html'" />
-</head>
-<body>
-</body>
+  <head>
+    <meta charset="utf-8">
+    <title>Redirecting...</title>
+    <script>
+      sessionStorage.redirect = location.pathname;
+    </script>
+    <meta http-equiv="refresh" content="0;URL='/sapphire-resto-website/'">
+  </head>
+  <body>
+  </body>
 </html>


### PR DESCRIPTION
The application was using an incomplete implementation of the `404.html` redirect trick for handling client-side routing on GitHub Pages. This caused the application to fail to load the correct route on page refresh.

This commit fixes the redirect mechanism by:
1.  Updating `public/404.html` to store the full path of the requested URL in `sessionStorage`.
2.  Updating the script in `index.html` to correctly use the stored path to restore the URL, allowing `BrowserRouter` to handle the routing.